### PR TITLE
Upgrade Hystrix

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<archaius.version>0.7.6</archaius.version>
 		<concurrency-limits.version>0.1.6</concurrency-limits.version>
 		<eureka.version>1.9.7</eureka.version>
-		<hystrix.version>1.5.12</hystrix.version>
+		<hystrix.version>1.5.18</hystrix.version>
 		<ribbon.version>2.3.0</ribbon.version>
 		<servo.version>0.12.21</servo.version>
 		<zuul.version>1.3.1</zuul.version>


### PR DESCRIPTION
Hystrix 1.5.11 was re-released as 1.5.18, s. https://github.com/Netflix/Hystrix/issues/1891 and https://github.com/Netflix/Hystrix/releases/tag/v1.5.18